### PR TITLE
Expose Prometheus client

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
 declare module '@banno/epimetheus' {
   function instrument(server: any, opts?: any) : any
+  function getClient() : any
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const hapi = require('./lib/hapi')
 const express = require('./lib/express')
 const restify = require('./lib/restify')
 const http = require('./lib/http')
+const metrics = require('./lib/metrics')
 
 function instrument (app, options) {
   options = defaults(options)
@@ -19,5 +20,6 @@ function instrument (app, options) {
 }
 
 module.exports = {
-  instrument: instrument
+  instrument: instrument,
+  getClient: () => metrics.client
 }

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -30,5 +30,6 @@ function observe (method, path, statusCode, start) {
 
 module.exports = {
   observe: observe,
+  client: client,
   summary: () => client.register.metrics()
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@banno/epimetheus",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "node middleware to automatically instrument node applications for consumption by prometheus",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In order to track custom metrics in applications that consume this library, the underlying Prometheus client stored in this library needs to be accessible.